### PR TITLE
Detect if defaults supplied accept header.

### DIFF
--- a/DynamicRestProxy.Portable/HttpClientFactory.cs
+++ b/DynamicRestProxy.Portable/HttpClientFactory.cs
@@ -14,11 +14,13 @@ namespace DynamicRestProxy.PortableHttpClient
             client.BaseAddress = baseUri;
 
             client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/json"));
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/x-json"));
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/javascript"));
-
+            if (defaults == null || !defaults.DefaultHeaders.ContainsKey("Accept"))
+            {
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/json"));
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/x-json"));
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/javascript"));
+            }
             if (handler is HttpClientHandler && ((HttpClientHandler)handler).SupportsTransferEncodingChunked())
             {
                 client.DefaultRequestHeaders.TransferEncodingChunked = true;


### PR DESCRIPTION
A Restful API I use only likes one Accept header value or it will default to XML.  This change detects if the user supplied an Accept header, it will then just clear the default and not add the ones specified in the factory.

Note, I'm on an airplane and my Visual Studio is acting flakey on my laptop, so I couldn't run unit tests or even compile.. don't ask.. have old laptop and I don't have latest update of Studio 2013 or 2015 and I couldn't open the main project file.   And to top it off this is my first commit to git.. ever..  Great project, going to save me a ton of time.